### PR TITLE
Single and only tg per service approach

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.gem
+.rubocop-https*

--- a/.rubocop-shared.yml
+++ b/.rubocop-shared.yml
@@ -1,0 +1,2 @@
+inherit_from:
+- https://raw.githubusercontent.com/simplepractice/rubocop-simplepractice/v0.83.0-1/.rubocop-shared.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,4 @@
+inherit_from:
+- ./.rubocop-shared.yml
+AllCops:
+  TargetRubyVersion: 2.7

--- a/bin/blue_green_switch
+++ b/bin/blue_green_switch
@@ -3,11 +3,9 @@
 require "aws-sdk-elasticloadbalancingv2"
 
 REGION = "us-west-2".freeze
-lb_name = ARGV[0]
-lb_port = 443
-domain = ARGV[1]
-tg_prefix = ARGV[2]
-color = ARGV[3]
+tg_name = ARGV[0]
+color = ARGV[1]
+color_port = ARGV[2]
 
 class AWSClient
   class << self
@@ -18,29 +16,74 @@ class AWSClient
 end
 
 
-alb = AWSClient.elbv2.describe_load_balancers.load_balancers.find { |x| x.load_balancer_name == lb_name }
-listener = AWSClient.elbv2.describe_listeners(load_balancer_arn: alb.load_balancer_arn).listeners.find { |x| x.port == lb_port }
-rule = AWSClient.elbv2.describe_rules(listener_arn: listener.listener_arn).rules.find { |x| x.conditions.first.values.include? domain }
-tg_green = AWSClient.elbv2.describe_target_groups.target_groups.find { |x| x.target_group_name == "#{tg_prefix}-green" }
-tg_blue = AWSClient.elbv2.describe_target_groups.target_groups.find { |x| x.target_group_name == "#{tg_prefix}-blue" }
-
-if color == "green"
+if color_port == nil
+  fail "Cannot detect current color_port. Color_port not passed in cli?"
+elsif color == "green"
   puts "Switching to green"
-  tg_color = tg_green.target_group_arn
 elsif color == "blue"
   puts "Switching to blue"
-  tg_color = tg_blue.target_group_arn
 else
   fail "Cannot detect current color. Color not passed in cli?"
 end
 
-targets = AWSClient.elbv2.describe_target_health(target_group_arn: tg_color)
+tg = AWSClient.elbv2.describe_target_groups.target_groups.find { |x| x.target_group_name == "#{tg_name}" }
+targets = AWSClient.elbv2.describe_target_health(target_group_arn: tg.target_group_arn)
             .target_health_descriptions.map(&:target)
+targets_ids = targets.map(&:id)
+targets_port = targets.map(&:port).uniq[0]
 
-AWSClient.elbv2.wait_until(
-  :target_in_service,
-  target_group_arn: tg_color,
-  targets: targets
-)
+targets_ids.each do |i|
+  AWSClient.elbv2.register_targets({
+    target_group_arn: tg.target_group_arn, 
+    targets: [
+      {
+        id: i,
+        port: color_port,
+      },
+    ],
+  })
+end
 
-AWSClient.elbv2.modify_rule(rule_arn: rule.rule_arn, actions: [{ type: "forward", target_group_arn: tg_color }])
+targets_ids.each do |i|
+  AWSClient.elbv2.wait_until(
+    :target_in_service,
+    target_group_arn: tg.target_group_arn,
+    targets: [
+      {
+        id: i,
+        port: color_port
+      },
+    ]
+  )
+end
+
+puts color.capitalize + " target in service"
+puts "De-registering an old one"
+
+targets_ids.each do |i|
+  AWSClient.elbv2.deregister_targets({
+    target_group_arn: tg.target_group_arn, 
+    targets: [
+      {
+        id: i,
+        port: targets_port
+      }, 
+    ], 
+  })
+end
+
+targets_ids.each do |i|
+  AWSClient.elbv2.wait_until(
+    :target_deregistered,
+    target_group_arn: tg.target_group_arn,
+    targets: [
+      {
+        id: i,
+        port: targets_port
+      },
+    ]
+  )
+end
+
+puts
+puts "Blue-green switch completed"

--- a/bin/blue_green_switch
+++ b/bin/blue_green_switch
@@ -26,60 +26,39 @@ end
 tg = AWSClient.elbv2.describe_target_groups.target_groups.find { |x| x.target_group_name == tg_name }
 targets = AWSClient.elbv2.describe_target_health(target_group_arn: tg.target_group_arn)
                    .target_health_descriptions.map(&:target)
-targets_ids = targets.map(&:id)
-targets_port = targets.map(&:port).uniq.first
 
-targets_ids.each do |i|
-  AWSClient.elbv2.register_targets({
-    target_group_arn: tg.target_group_arn,
-    targets: [
-      {
-        id: i,
-        port: color_port
-      },
-    ]
-  })
+new_targets = []
+targets.map(&:id).each do |i|
+  new_targets <<
+    {
+      id: i,
+      port: color_port
+    }
 end
 
-targets_ids.each do |i|
-  AWSClient.elbv2.wait_until(
-    :target_in_service,
-    target_group_arn: tg.target_group_arn,
-    targets: [
-      {
-        id: i,
-        port: color_port
-      },
-    ]
-  )
-end
+AWSClient.elbv2.register_targets({
+  target_group_arn: tg.target_group_arn,
+  targets: new_targets
+})
 
-puts "#{color.capitalize} target in service"
+AWSClient.elbv2.wait_until(
+  :target_in_service,
+  target_group_arn: tg.target_group_arn,
+  targets: new_targets
+)
+
+puts "\n#{color.capitalize} target in service"
 puts "De-registering an old one"
 
-targets_ids.each do |i|
-  AWSClient.elbv2.deregister_targets({
-    target_group_arn: tg.target_group_arn,
-    targets: [
-      {
-        id: i,
-        port: targets_port
-      },
-    ]
-  })
-end
+AWSClient.elbv2.deregister_targets({
+  target_group_arn: tg.target_group_arn,
+  targets: targets
+})
 
-targets_ids.each do |i|
-  AWSClient.elbv2.wait_until(
-    :target_deregistered,
-    target_group_arn: tg.target_group_arn,
-    targets: [
-      {
-        id: i,
-        port: targets_port
-      },
-    ]
-  )
-end
+AWSClient.elbv2.wait_until(
+  :target_deregistered,
+  target_group_arn: tg.target_group_arn,
+  targets: targets
+)
 
 puts "\nBlue-green switch completed"

--- a/bin/blue_green_switch
+++ b/bin/blue_green_switch
@@ -7,20 +7,20 @@ tg_name = ARGV[0]
 color = ARGV[1]
 color_port = ARGV[2]
 
+if color_port.nil?
+  fail "Cannot detect current color_port. Color_port not passed in cli?"
+elsif ["blue", "green"].include?(color)
+  puts "Switching to #{color}"
+else
+  fail "Cannot detect current color. Wrong color passed in cli?"
+end
+
 class AWSClient
   class << self
     def elbv2
       @elbv2 ||= Aws::ElasticLoadBalancingV2::Client.new(region: REGION)
     end
   end
-end
-
-if color_port.nil?
-  fail "Cannot detect current color_port. Color_port not passed in cli?"
-elsif ["blue", "green"].include?(color)
-  puts "Switching to #{color}"
-else
-  fail "Cannot detect current color. Color not passed in cli?"
 end
 
 tg = AWSClient.elbv2.describe_target_groups.target_groups.find { |x| x.target_group_name == tg_name }

--- a/bin/blue_green_switch
+++ b/bin/blue_green_switch
@@ -15,32 +15,29 @@ class AWSClient
   end
 end
 
-
-if color_port == nil
+if color_port.nil?
   fail "Cannot detect current color_port. Color_port not passed in cli?"
-elsif color == "green"
-  puts "Switching to green"
-elsif color == "blue"
-  puts "Switching to blue"
+elsif ["blue", "green"].include?(color)
+  puts "Switching to #{color}"
 else
   fail "Cannot detect current color. Color not passed in cli?"
 end
 
-tg = AWSClient.elbv2.describe_target_groups.target_groups.find { |x| x.target_group_name == "#{tg_name}" }
+tg = AWSClient.elbv2.describe_target_groups.target_groups.find { |x| x.target_group_name == tg_name }
 targets = AWSClient.elbv2.describe_target_health(target_group_arn: tg.target_group_arn)
-            .target_health_descriptions.map(&:target)
+                   .target_health_descriptions.map(&:target)
 targets_ids = targets.map(&:id)
-targets_port = targets.map(&:port).uniq[0]
+targets_port = targets.map(&:port).uniq.first
 
 targets_ids.each do |i|
   AWSClient.elbv2.register_targets({
-    target_group_arn: tg.target_group_arn, 
+    target_group_arn: tg.target_group_arn,
     targets: [
       {
         id: i,
-        port: color_port,
+        port: color_port
       },
-    ],
+    ]
   })
 end
 
@@ -57,18 +54,18 @@ targets_ids.each do |i|
   )
 end
 
-puts color.capitalize + " target in service"
+puts "#{color.capitalize} target in service"
 puts "De-registering an old one"
 
 targets_ids.each do |i|
   AWSClient.elbv2.deregister_targets({
-    target_group_arn: tg.target_group_arn, 
+    target_group_arn: tg.target_group_arn,
     targets: [
       {
         id: i,
         port: targets_port
-      }, 
-    ], 
+      },
+    ]
   })
 end
 
@@ -85,5 +82,4 @@ targets_ids.each do |i|
   )
 end
 
-puts
-puts "Blue-green switch completed"
+puts "\nBlue-green switch completed"

--- a/bin/detect_inactive_color
+++ b/bin/detect_inactive_color
@@ -1,22 +1,22 @@
 #!/usr/bin/env ruby
-require 'aws-sdk-elasticloadbalancingv2'
+require "aws-sdk-elasticloadbalancingv2"
 
 tg_name = ARGV[0]
 blue_port = ARGV[1]
 green_port = ARGV[2]
 
 client = Aws::ElasticLoadBalancingV2::Client.new
-tg = client.describe_target_groups.target_groups.find { |x| x.target_group_name == "#{tg_name}" }
+tg = client.describe_target_groups.target_groups.find { |x| x.target_group_name == tg_name }
 targets = client.describe_target_health(target_group_arn: tg.target_group_arn)
-            .target_health_descriptions.map(&:target)
+                .target_health_descriptions.map(&:target)
 target_ports = targets.map(&:port).uniq
 
 if target_ports.count > 1
-  fail 'Both ports are active'
-elsif target_ports[0] == blue_port.to_i
-  puts 'green'
-elsif target_ports[0] == green_port.to_i
-  puts 'blue'
+  fail "Both ports are active"
+elsif target_ports.first == blue_port.to_i
+  puts "green"
+elsif target_ports.first == green_port.to_i
+  puts "blue"
 else
-  fail 'Cannot detect current color'
+  fail "Cannot detect current color"
 end

--- a/bin/detect_inactive_color
+++ b/bin/detect_inactive_color
@@ -1,18 +1,21 @@
 #!/usr/bin/env ruby
 require 'aws-sdk-elasticloadbalancingv2'
 
-lb_name = ARGV[0]
-lb_port = 443
-domain = ARGV[1]
+tg_name = ARGV[0]
+blue_port = ARGV[1]
+green_port = ARGV[2]
 
 client = Aws::ElasticLoadBalancingV2::Client.new
-alb = client.describe_load_balancers.load_balancers.find {|x| x.load_balancer_name==lb_name}
-listener = client.describe_listeners(load_balancer_arn: alb.load_balancer_arn).listeners.find {|x| x.port == lb_port}
-rule = client.describe_rules(listener_arn: listener.listener_arn).rules.find {|x| x.conditions.first.values.include? domain}
+tg = client.describe_target_groups.target_groups.find { |x| x.target_group_name == "#{tg_name}" }
+targets = client.describe_target_health(target_group_arn: tg.target_group_arn)
+            .target_health_descriptions.map(&:target)
+target_ports = targets.map(&:port).uniq
 
-if rule.actions.first.target_group_arn.include? 'blue'
+if target_ports.count > 1
+  fail 'Both ports are active'
+elsif target_ports[0] == blue_port.to_i
   puts 'green'
-elsif rule.actions.first.target_group_arn.include? 'green'
+elsif target_ports[0] == green_port.to_i
   puts 'blue'
 else
   fail 'Cannot detect current color'

--- a/deploy-tools.gemspec
+++ b/deploy-tools.gemspec
@@ -1,10 +1,10 @@
 Gem::Specification.new do |s|
   s.name        = 'deploy-tools'
-  s.version     = '0.0.5'
-  s.date        = '2021-03-17'
+  s.version     = '0.1.0'
+  s.date        = '2022-01-25'
   s.summary     = "Deploy tools"
   s.description = "A set of script used for deployment"
-  s.authors     = ["Tony Nyurkin"]
+  s.authors     = ["Tony Nyurkin", "Serhii Voronoi"]
   s.email       = 'tony@simplepractice.com'
   s.files       = `git ls-files `.split("\n")
   s.bindir      = "bin"

--- a/deploy-tools.gemspec
+++ b/deploy-tools.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name        = 'deploy-tools'
   s.version     = '0.1.0'
-  s.date        = '2022-01-25'
+  s.date        = '2022-01-27'
   s.summary     = "Deploy tools"
   s.description = "A set of script used for deployment"
   s.authors     = ["Tony Nyurkin", "Serhii Voronoi"]


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/180098892

Before I move on to ansible\ci\terraform changes I'd like to confirm suggested approach in this PR.

Commands in ansible will be look like this:
```
local_action: "shell detect_inactive_color simplepractice {{ blue_port }} {{ green_port }}"
local_action: "shell blue_green_switch simplepractice {{ color.stdout }} {{ color_port }}"
local_action: "shell blue_green_switch client-portal {{ color.stdout }} {{ client_portal_color_port }}"
local_action: "shell blue_green_switch simplepractice-internal {{ color.stdout }} {{ color_port }}"
```

`color_port` most likely will be set by `set_fact` based on `color.stdout` condition (or just hardcoded)
