### PR TITLE
Add optional targets_list argument

### DIFF
--- a/bin/blue_green_switch
+++ b/bin/blue_green_switch
@@ -6,6 +6,7 @@ REGION = "us-west-2".freeze
 tg_name = ARGV[0]
 color = ARGV[1]
 color_port = ARGV[2]
+targets_list = ARGV[3]
 
 if color_port.nil?
   fail "Cannot detect current color_port. Color_port not passed in cli?"
@@ -29,12 +30,22 @@ targets = AWSClient.elbv2.describe_target_health(target_group_arn: tg.target_gro
 targets_port = targets.map(&:port).uniq.first
 
 new_targets = []
-targets.map(&:id).each do |i|
-  new_targets <<
-    {
-      id: i,
-      port: color_port
-    }
+if targets_list.nil?
+  targets.map(&:id).each do |i|
+    new_targets <<
+      {
+        id: i,
+        port: color_port
+      }
+  end
+else
+  targets_list.split(",").each do |i|
+    new_targets <<
+      {
+        id: i,
+        port: color_port
+      }
+  end
 end
 
 AWSClient.elbv2.register_targets({

--- a/bin/blue_green_switch
+++ b/bin/blue_green_switch
@@ -29,23 +29,20 @@ targets = AWSClient.elbv2.describe_target_health(target_group_arn: tg.target_gro
                    .target_health_descriptions.map(&:target)
 targets_port = targets.map(&:port).uniq.first
 
-new_targets = []
 if targets_list.nil?
-  targets.map(&:id).each do |i|
-    new_targets <<
-      {
-        id: i,
-        port: color_port
-      }
-  end
+  targets_ids = targets.map(&:id)
 else
-  targets_list.split(",").each do |i|
-    new_targets <<
-      {
-        id: i,
-        port: color_port
-      }
-  end
+  targets_ids = targets_list.split(",")
+end
+
+new_targets = []
+
+targets_ids.each do |i|
+  new_targets <<
+    {
+      id: i,
+      port: color_port
+    }
 end
 
 AWSClient.elbv2.register_targets({

--- a/deploy-tools.gemspec
+++ b/deploy-tools.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name        = 'deploy-tools'
-  s.version     = '0.1.1'
-  s.date        = '2022-02-01'
+  s.version     = '0.1.2'
+  s.date        = '2022-06-28'
   s.summary     = "Deploy tools"
   s.description = "A set of script used for deployment"
   s.authors     = ["Tony Nyurkin", "Serhii Voronoi"]


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/170425434

Because we moved tg_attachements from terraform to deploy-tools now we need to manually add targets to target groups when adding new instances.

With this changes we can specify a list of instances instead.